### PR TITLE
Upgrade Java runtime from 17 to 21 (latest LTS)

### DIFF
--- a/http/pom.xml
+++ b/http/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <azure.functions.maven.plugin.version>1.36.0</azure.functions.maven.plugin.version>
         <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
         <functionAppName>contoso-functions</functionAppName>
@@ -83,7 +83,7 @@
                     <runtime>
                         <!-- runtime os, could be windows, linux or docker-->
                         <os>linux</os>
-                        <javaVersion>17</javaVersion>
+                        <javaVersion>21</javaVersion>
                     </runtime>
                     <appSettings>
                         <property>

--- a/infra/core/host/functions-flexconsumption.bicep
+++ b/infra/core/host/functions-flexconsumption.bicep
@@ -17,7 +17,7 @@ param identityId string
   'dotnet-isolated', 'node', 'python', 'java', 'powershell', 'custom'
 ])
 param runtimeName string
-@allowed(['3.10', '3.11', '7.4', '8.0', '10', '11', '17', '20'])
+@allowed(['3.10', '3.11', '7.4', '8.0', '10', '11', '17', '20', '21'])
 param runtimeVersion string
 param kind string = 'functionapp,linux'
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -59,7 +59,7 @@ module api './app/api.bicep' = {
     applicationInsightsName: monitoring.outputs.applicationInsightsName
     appServicePlanId: appServicePlan.outputs.id
     runtimeName: 'java'
-    runtimeVersion: '17'
+    runtimeVersion: '21'
     storageAccountName: storage.outputs.name
     identityId: apiUserAssignedIdentity.outputs.identityId
     identityClientId: apiUserAssignedIdentity.outputs.identityClientId


### PR DESCRIPTION
## Summary

Upgrades the Java runtime from 17 to 21, which is the latest LTS version supported by Azure Functions.

## Changes

### infra/main.bicep
- Changed `runtimeVersion: '17'` to `runtimeVersion: '21'`

### http/pom.xml
- Changed `<java.version>17</java.version>` to `<java.version>21</java.version>`
- Changed `<javaVersion>17</javaVersion>` to `<javaVersion>21</javaVersion>`

## Why This Change?

Java 21 is the latest LTS (Long Term Support) version with:
- Virtual Threads (Project Loom) - improved concurrency
- Pattern Matching for switch
- Record Patterns
- Better performance and GC improvements

Fixes #15